### PR TITLE
improper shell variable, fixed

### DIFF
--- a/scripts/archiveGridFiles.sh
+++ b/scripts/archiveGridFiles.sh
@@ -4,32 +4,32 @@
 DIR_ORIG=$PWD
 
 # Make temporary directory
-mkdir $GEM_BASE/tmp
+mkdir $FRAMEWORK_BASE/tmp
 
 # Move run config files
-mv $GEM_BASE/config/configRun_JobNo*.cfg $GEM_BASE/tmp
+mv $FRAMEWORK_BASE/config/configRun_JobNo*.cfg $FRAMEWORK_BASE/tmp
 
 # Move submission scripts
-mv $GEM_BASE/scripts/submitFrameworkJob_JobNo*.sh $GEM_BASE/tmp
+mv $FRAMEWORK_BASE/scripts/submitFrameworkJob_JobNo*.sh $FRAMEWORK_BASE/tmp
 
 # Move std err, log, and out files
-mv $GEM_BASE/stderr/*.txt $GEM_BASE/tmp
-mv $GEM_BASE/stdlog/*.txt $GEM_BASE/tmp
-mv $GEM_BASE/stdout/*.txt $GEM_BASE/tmp
+mv $FRAMEWORK_BASE/stderr/*.txt $FRAMEWORK_BASE/tmp
+mv $FRAMEWORK_BASE/stdlog/*.txt $FRAMEWORK_BASE/tmp
+mv $FRAMEWORK_BASE/stdout/*.txt $FRAMEWORK_BASE/tmp
 
 # Move to temporary directory
-cd $GEM_BASE/tmp
+cd $FRAMEWORK_BASE/tmp
 
 # Get the Date 
 TODAY=`date +%Y-%m-%d-%H-%M-%S`
 
 # Archive
 tar -cf gridArchive_$TODAY.tar *
-mv gridArchive_$TODAY.tar $GEM_BASE
+mv gridArchive_$TODAY.tar $FRAMEWORK_BASE
 
 # Return to original directory
 cd $DIR_ORIG
 
 # Clean up temporary directory
-rm $GEM_BASE/tmp/*
-rmdir $GEM_BASE/tmp
+rm $FRAMEWORK_BASE/tmp/*
+rmdir $FRAMEWORK_BASE/tmp

--- a/scripts/cleanGridFiles.sh
+++ b/scripts/cleanGridFiles.sh
@@ -1,12 +1,12 @@
 #!/bin/zsh
 
 #Delete run config files
-rm $GEM_BASE/config/configRun_JobNo*.cfg
+rm $FRAMEWORK_BASE/config/configRun_JobNo*.cfg
 
 #Delete submission scripts
-rm $GEM_BASE/scripts/submitFrameworkJob_JobNo*.sh
+rm $FRAMEWORK_BASE/scripts/submitFrameworkJob_JobNo*.sh
 
 #Delete std err, log, and out files
-rm $GEM_BASE/stderr/*.txt
-rm $GEM_BASE/stdlog/*.txt
-rm $GEM_BASE/stdout/*.txt
+rm $FRAMEWORK_BASE/stderr/*.txt
+rm $FRAMEWORK_BASE/stdlog/*.txt
+rm $FRAMEWORK_BASE/stdout/*.txt

--- a/scripts/makeAllPlots.sh
+++ b/scripts/makeAllPlots.sh
@@ -16,7 +16,7 @@ for f in *.cfg
 do
 	echo "=============================================="
 	echo "Making plot from file:" $f
-	$GEM_BASE/genericPlotter $f false
+	$FRAMEWORK_BASE/genericPlotter $f false
 done
 
 echo "=============================================="

--- a/scripts/makeGainMaps.sh
+++ b/scripts/makeGainMaps.sh
@@ -28,9 +28,9 @@ do
 		echo "processing file: " ${argList[1]}
 		echo "with command:"
 		echo ""
-		echo python2.7 $GEM_BASE/python/computeGainMap.py --file=${argList[1]} --gp0=${argList[2]} --gp0Err=${argList[3]} --gp1=${argList[4]} --gp1Err=${argList[5]} --name=${argList[6]} --hvPoint=${argList[7]} --hvlist=${argList[8]} --fileMap=${argList[9]}
+		echo python2.7 $FRAMEWORK_BASE/python/computeGainMap.py --file=${argList[1]} --gp0=${argList[2]} --gp0Err=${argList[3]} --gp1=${argList[4]} --gp1Err=${argList[5]} --name=${argList[6]} --hvPoint=${argList[7]} --hvlist=${argList[8]} --fileMap=${argList[9]}
 		echo ""
-		python2.7 $GEM_BASE/python/computeGainMap.py --file=${argList[1]} --gp0=${argList[2]} --gp0Err=${argList[3]} --gp1=${argList[4]} --gp1Err=${argList[5]} --name=${argList[6]} --hvPoint=${argList[7]} --hvlist=${argList[8]} --fileMap=${argList[9]}
+		python2.7 $FRAMEWORK_BASE/python/computeGainMap.py --file=${argList[1]} --gp0=${argList[2]} --gp0Err=${argList[3]} --gp1=${argList[4]} --gp1Err=${argList[5]} --name=${argList[6]} --hvPoint=${argList[7]} --hvlist=${argList[8]} --fileMap=${argList[9]}
 		echo ""
 		echo ""
 		echo "================="

--- a/scripts/runMode_Comparison.sh
+++ b/scripts/runMode_Comparison.sh
@@ -14,8 +14,8 @@
 DIR_ORIG=$PWD
 
 #store the run config file
-FILE_RUN=$GEM_BASE/config/configComp.cfg
-FILE_RUN_TEMP=$GEM_BASE/config/configComp_Template.cfg
+FILE_RUN=$FRAMEWORK_BASE/config/configComp.cfg
+FILE_RUN_TEMP=$FRAMEWORK_BASE/config/configComp_Template.cfg
 cp $FILE_RUN_TEMP $FILE_RUN
 
 #setup input variables
@@ -74,5 +74,5 @@ echo "To view this file execute:"
 echo "gedit $FILE_RUN &"
 echo ""
 echo "To launch the analysis execute:"
-echo "cd $GEM_BASE"
+echo "cd $FRAMEWORK_BASE"
 echo "./frameworkMain $FILE_RUN true"

--- a/scripts/runMode_Grid.sh
+++ b/scripts/runMode_Grid.sh
@@ -30,7 +30,7 @@ strcmp() {
 DIR_ORIG=$PWD
 
 #store the run config file
-FILE_RUN_TEMP=$GEM_BASE/config/configRun_Template_Grid.cfg
+FILE_RUN_TEMP=$FRAMEWORK_BASE/config/configRun_Template_Grid.cfg
 
 #setup input variables
 NAME_DET=$1
@@ -44,23 +44,23 @@ CMS_GEM_EOS_COMM=/eos/cms/store/group/dpg_gem/comm_gem/QualityControl
 EOS=/afs/cern.ch/project/eos/installation/0.3.84-aquamarine/bin/eos.select
 
 #Check for the stderr directory
-DIR_STDERR=$GEM_BASE/stderr
+DIR_STDERR=$FRAMEWORK_BASE/stderr
 if [[ !  -d $DIR_STDERR ]]; then
-    echo "Creating stdout directory: $GEM_BASE/stderr"
+    echo "Creating stdout directory: $FRAMEWORK_BASE/stderr"
     mkdir $DIR_STDERR
 fi
 
 #Check for the stdlog directory
-DIR_STDLOG=$GEM_BASE/stdlog
+DIR_STDLOG=$FRAMEWORK_BASE/stdlog
 if [[ ! -d $DIR_STDLOG ]]; then
-    echo "Creating stdout directory: $GEM_BASE/stdlog"
+    echo "Creating stdout directory: $FRAMEWORK_BASE/stdlog"
     mkdir $DIR_STDLOG
 fi
 
 #Check for the stdout directory
-DIR_STDOUT=$GEM_BASE/stdout
+DIR_STDOUT=$FRAMEWORK_BASE/stdout
 if [[ ! -d $DIR_STDOUT ]]; then
-    echo "Creating stdout directory: $GEM_BASE/stdout"
+    echo "Creating stdout directory: $FRAMEWORK_BASE/stdout"
     mkdir $DIR_STDOUT
 fi
 
@@ -72,7 +72,7 @@ do
     let COUNTER=$(( ${COUNTER} + 1 ))
 
     #copy file
-    FILE_RUN=$GEM_BASE/config/configRun_JobNo${COUNTER}.cfg
+    FILE_RUN=$FRAMEWORK_BASE/config/configRun_JobNo${COUNTER}.cfg
     cp $FILE_RUN_TEMP $FILE_RUN
 
     #Replace Detector Name
@@ -123,12 +123,12 @@ do
 
     #make the script to send to the scheduler
     DIR_JOBNUM=/tmp/JobNo${COUNTER}
-    DIR_SCRIPTS=$GEM_BASE/scripts
-    FILE_SCRIPT=$GEM_BASE/scripts/submitFrameworkJob_JobNo${COUNTER}.sh
+    DIR_SCRIPTS=$FRAMEWORK_BASE/scripts
+    FILE_SCRIPT=$FRAMEWORK_BASE/scripts/submitFrameworkJob_JobNo${COUNTER}.sh
     echo '#!/bin/zsh' >> $FILE_SCRIPT
     echo "" >> $FILE_SCRIPT
     echo "#Setup environment" >> $FILE_SCRIPT
-    echo "cd $GEM_BASE" >> $FILE_SCRIPT
+    echo "cd $FRAMEWORK_BASE" >> $FILE_SCRIPT
     echo "source scripts/setup_CMS_GEM.sh" >> $FILE_SCRIPT
     echo "" >> $FILE_SCRIPT
     echo "#Make temporary directory" >> $FILE_SCRIPT

--- a/scripts/runMode_Grid_Reco.sh
+++ b/scripts/runMode_Grid_Reco.sh
@@ -30,7 +30,7 @@ strcmp() {
 DIR_ORIG=$PWD
 
 #store the run config file
-FILE_RUN_TEMP=$GEM_BASE/config/configRun_Template_Grid_Reco.cfg
+FILE_RUN_TEMP=$FRAMEWORK_BASE/config/configRun_Template_Grid_Reco.cfg
 
 #setup input variables
 NAME_DET=$1
@@ -44,23 +44,23 @@ CMS_GEM_EOS_COMM=/eos/cms/store/group/dpg_gem/comm_gem/QualityControl
 EOS=/afs/cern.ch/project/eos/installation/0.3.84-aquamarine/bin/eos.select
 
 #Check for the stderr directory
-DIR_STDERR=$GEM_BASE/stderr
+DIR_STDERR=$FRAMEWORK_BASE/stderr
 if [[ !  -d $DIR_STDERR ]]; then
-    echo "Creating stdout directory: $GEM_BASE/stderr"
+    echo "Creating stdout directory: $FRAMEWORK_BASE/stderr"
     mkdir $DIR_STDERR
 fi
 
 #Check for the stdlog directory
-DIR_STDLOG=$GEM_BASE/stdlog
+DIR_STDLOG=$FRAMEWORK_BASE/stdlog
 if [[ ! -d $DIR_STDLOG ]]; then
-    echo "Creating stdout directory: $GEM_BASE/stdlog"
+    echo "Creating stdout directory: $FRAMEWORK_BASE/stdlog"
     mkdir $DIR_STDLOG
 fi
 
 #Check for the stdout directory
-DIR_STDOUT=$GEM_BASE/stdout
+DIR_STDOUT=$FRAMEWORK_BASE/stdout
 if [[ ! -d $DIR_STDOUT ]]; then
-    echo "Creating stdout directory: $GEM_BASE/stdout"
+    echo "Creating stdout directory: $FRAMEWORK_BASE/stdout"
     mkdir $DIR_STDOUT
 fi
 
@@ -72,7 +72,7 @@ do
     let COUNTER=$(( ${COUNTER} + 1 ))
 
     #copy file
-    FILE_RUN=$GEM_BASE/config/configRun_JobNo${COUNTER}.cfg
+    FILE_RUN=$FRAMEWORK_BASE/config/configRun_JobNo${COUNTER}.cfg
     cp $FILE_RUN_TEMP $FILE_RUN
 
     #Replace filenames - Reco
@@ -120,12 +120,12 @@ do
 
     #make the script to send to the scheduler
     DIR_JOBNUM=/tmp/JobNo${COUNTER}
-    DIR_SCRIPTS=$GEM_BASE/scripts
-    FILE_SCRIPT=$GEM_BASE/scripts/submitFrameworkJob_JobNo${COUNTER}.sh
+    DIR_SCRIPTS=$FRAMEWORK_BASE/scripts
+    FILE_SCRIPT=$FRAMEWORK_BASE/scripts/submitFrameworkJob_JobNo${COUNTER}.sh
     echo '#!/bin/zsh' >> $FILE_SCRIPT
     echo "" >> $FILE_SCRIPT
     echo "#Setup environment" >> $FILE_SCRIPT
-    echo "cd $GEM_BASE" >> $FILE_SCRIPT
+    echo "cd $FRAMEWORK_BASE" >> $FILE_SCRIPT
     echo "source scripts/setup_CMS_GEM.sh" >> $FILE_SCRIPT
     echo "" >> $FILE_SCRIPT
     echo "#Make temporary directory" >> $FILE_SCRIPT

--- a/scripts/runMode_Rerun.sh
+++ b/scripts/runMode_Rerun.sh
@@ -6,8 +6,8 @@
 DIR_ORIG=$PWD
 
 #store the run config file
-FILE_RUN=$GEM_BASE/config/configRun.cfg
-FILE_RUN_TEMP=$GEM_BASE/config/configRun_Template_Rerun.cfg
+FILE_RUN=$FRAMEWORK_BASE/config/configRun.cfg
+FILE_RUN_TEMP=$FRAMEWORK_BASE/config/configRun_Template_Rerun.cfg
 cp $FILE_RUN_TEMP $FILE_RUN
 
 #setup input variables
@@ -48,5 +48,5 @@ echo "To view this file execute:"
 echo "gedit $FILE_RUN &"
 echo ""
 echo "To launch the analysis execute:"
-echo "cd $GEM_BASE"
+echo "cd $FRAMEWORK_BASE"
 echo "./frameworkMain $FILE_RUN true"

--- a/scripts/runMode_Series.sh
+++ b/scripts/runMode_Series.sh
@@ -6,8 +6,8 @@
 DIR_ORIG=$PWD
 
 #store the run config file
-FILE_RUN=$GEM_BASE/config/configRun.cfg
-FILE_RUN_TEMP=$GEM_BASE/config/configRun_Template_Series.cfg
+FILE_RUN=$FRAMEWORK_BASE/config/configRun.cfg
+FILE_RUN_TEMP=$FRAMEWORK_BASE/config/configRun_Template_Series.cfg
 cp $FILE_RUN_TEMP $FILE_RUN
 
 #setup input variables
@@ -48,5 +48,5 @@ echo "To view this file execute:"
 echo "gedit $FILE_RUN &"
 echo ""
 echo "To launch the analysis execute:"
-echo "cd $GEM_BASE"
+echo "cd $FRAMEWORK_BASE"
 echo "./frameworkMain $FILE_RUN true"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrong shell variable `$GEM_BASE` was referenced instead of `$FRAMEWORK_BASE` in several scripts.  Fixed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Scripts had outdated shell variable `$GEM_BASE` instead of `$FRAMEWORK_BASE`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change is trivial

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
